### PR TITLE
Add hint to CT query.

### DIFF
--- a/src/main/scala/palefat/data/mirror/builders/ChangeTrackingBuilder.scala
+++ b/src/main/scala/palefat/data/mirror/builders/ChangeTrackingBuilder.scala
@@ -33,7 +33,7 @@ object ChangeTrackingBuilder {
        |SELECT
        |    T.*, CT.SYS_CHANGE_OPERATION, $primaryKeySelectClause
        |FROM
-       |    [$schema].[$sourceTable] AS T
+       |    [$schema].[$sourceTable] AS T WITH (FORCESEEK)
        |RIGHT OUTER JOIN
        |    CHANGETABLE(CHANGES [$schema].[$sourceTable], $changeTrackingLastVersion) AS CT
        |ON


### PR DESCRIPTION
Add FORCESEEK hint to CT query to prevent scan on massive tables when selecting changes.