### PR TITLE
v1.0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.13.5"
 val sparkVersion = "3.2.3"
-version := s"1.0.3-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.0.4-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",


### PR DESCRIPTION
## 1.0.4 (2023-02-09)

#### Improvements
  - Allow to use query + where (#14)
  - Added `_platform_ingested_at column` to `DataframeBuilder` (#19)
  - Improved logging — added `timestamp` and additional messages (#21)
#### Bugfixes
  - Spark application failure while running z-ordering (#16)
  - Fix incorrect flow when using `change_tracking==true` (#23)
#### Dependencies
  - Switch to spark 3.2.3, scala 2.13.5 and delta 2.0.1 (#18)