### PR TITLE
Replaced drop+create with CREATE IF NOT EXISTS

### DIFF
--- a/src/main/scala/mirroring/builders/SqlBuilder.scala
+++ b/src/main/scala/mirroring/builders/SqlBuilder.scala
@@ -45,16 +45,12 @@ object SqlBuilder extends LogSupport {
     s" AND $dtFlt >= '${startDate}T00:00:00.000' AND $dtFlt < '${endDate}T00:00:00.000'"
   }
 
-  def buildDropTableSQL(db: String, tab: String): String = {
-    s"DROP TABLE IF EXISTS `$db`.`$tab`;"
-  }
-
   def buildCreateTableSQL(
       db: String,
       tab: String,
       dataPath: String
   ): String = {
-    s"""CREATE EXTERNAL TABLE `$db`.`$tab`
+    s"""CREATE EXTERNAL TABLE IF NOT EXISTS `$db`.`$tab`
     |USING DELTA
     |LOCATION '$dataPath';
     """.stripMargin

--- a/src/main/scala/mirroring/services/SqlService.scala
+++ b/src/main/scala/mirroring/services/SqlService.scala
@@ -29,25 +29,15 @@ object SqlService extends LogSupport {
 
     val createDbSQL =
       SqlBuilder.buildCreateDbSQL(config.hiveDb, config.hiveDbLocation)
-    val dropTableSQL =
-      SqlBuilder.buildDropTableSQL(config.hiveDb, config.targetTableName)
     val createTableSQL = SqlBuilder.buildCreateTableSQL(
       config.hiveDb,
       config.targetTableName,
       config.pathToSave
     )
-    val alterTableSQL = SqlBuilder.buildAlterTableSQL(
-      config.hiveDb,
-      config.targetTableName,
-      config.logRetentionDuration,
-      config.deletedFileRetentionDuration
-    )
 
     if (DeltaTable.isDeltaTable(spark, config.pathToSave)) {
       logger.info(s"Running SQL: $createDbSQL")
       spark.sql(createDbSQL)
-      logger.info(s"Running SQL: $dropTableSQL")
-      spark.sql(dropTableSQL)
       logger.info(s"Running SQL: $createTableSQL")
       spark.sql(createTableSQL)
 
@@ -70,6 +60,12 @@ object SqlService extends LogSupport {
         !logRetentionDuration.equals(config.logRetentionDuration) || !deletedFileRetentionDuration
           .equals(config.deletedFileRetentionDuration)
       ) {
+        val alterTableSQL = SqlBuilder.buildAlterTableSQL(
+          config.hiveDb,
+          config.targetTableName,
+          config.logRetentionDuration,
+          config.deletedFileRetentionDuration
+        )
         spark.sql(alterTableSQL)
       }
     }

--- a/src/test/scala/mirroring/SqlBuilderSuite.scala
+++ b/src/test/scala/mirroring/SqlBuilderSuite.scala
@@ -42,13 +42,6 @@ class SqlBuilderSuite extends AnyFunSuite {
     )
   }
 
-  test("buildDropTableSQL should create DROP TABLE statement") {
-    val table  = "Test1Table"
-    val db     = "default"
-    val result = SqlBuilder.buildDropTableSQL(db, table)
-    assert(result == "DROP TABLE IF EXISTS `default`.`Test1Table`;")
-  }
-
   test(
     "buildCreateTableSQL should generate CREATE EXTERNAL TABLE statement"
   ) {
@@ -61,7 +54,7 @@ class SqlBuilderSuite extends AnyFunSuite {
       dataPath
     )
     val expectedResult =
-      s"""CREATE EXTERNAL TABLE `default`.`Test1Table`
+      s"""CREATE EXTERNAL TABLE IF NOT EXISTS `default`.`Test1Table`
        |USING DELTA
        |LOCATION 's3a://bucket/folder';
     """.stripMargin


### PR DESCRIPTION
resolves #32 

### Description
This commit removes DROP operation and uses CREATE IF NOT EXISTS to create a new table

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
