### PR TITLE
v1.0.7.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.12.10"
 val sparkVersion = "3.3.2"
-version := s"1.0.6-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.0.7-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",


### PR DESCRIPTION
## 1.0.7 (2023-02-28)

#### Improvements
  - Removed schema evolution and added checks preventing mirroring when column names differ (#31 )
  - Update delta retention only if it differs from current (#34 )
  - Remove drop statement (#35 )
#### Bugfixes
  - Fix bug when external table can not be created (#33 )
  - Fix bug when table or view may not be selected while mirroring (#32 )
#### Dependencies
  - Switch to spark 3.3.2, scala 2.12.10 and delta 2.2.0 (#27 )
  - Scala 2.13 removed from test workflows (#28 )