### PR TITLE
Fix/40 broken ct flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.12.10"
 val sparkVersion = "3.3.2"
-version := s"1.0.8a1-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.0.8a3-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",

--- a/src/main/scala/mirroring/builders/JdbcBuilder.scala
+++ b/src/main/scala/mirroring/builders/JdbcBuilder.scala
@@ -21,6 +21,8 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import mirroring.builders.SqlBuilder.buildSQLObjectName
 import mirroring.services.SparkService.spark
+import mirroring.services.databases.JdbcContext
+
 import scala.collection.mutable.ListBuffer
 import wvlet.log.LogSupport
 
@@ -91,25 +93,22 @@ object JdbcBuilder extends LogSupport {
     sparkSession.createDataFrame(rdd, schema)
   }
 
-  def buildCTChangesQueryParams(
+  def buildCTQueryParams(
       CTChangesQueryParams: Array[String],
-      schema: String,
-      tab: String,
-      changeTrackingLastVersion: String,
-      ctCurrentVersion: String
+      jdbcContext: JdbcContext
   ): Array[String] = {
     var params: Array[String] = Array()
     for (param <- CTChangesQueryParams) {
       param match {
         case "defaultSQLTable" =>
           logger.info("Change Tracking default param used: SQLTable")
-          params :+= buildSQLObjectName(schema, tab)
+          params :+= buildSQLObjectName(jdbcContext.schema, jdbcContext.table)
         case "queryCTLastVersion" =>
           logger.info("Change Tracking default param used: querying last version")
-          params :+= changeTrackingLastVersion
+          params :+= jdbcContext.ctLastVersion.toString
         case "queryCTCurrentVersion" =>
           logger.info("Change Tracking default param used: querying current version")
-          params :+= ctCurrentVersion
+          params :+= jdbcContext.ctCurrentVersion.toString
         case _ =>
           params :+= param
       }

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -26,12 +26,9 @@ class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) w
 
   override def loadData(@annotation.unused _query: String = ""): DataFrame = {
     val connection = DriverManager.getConnection(url)
-    val params: Array[String] = JdbcBuilder.buildCTChangesQueryParams(
+    val params: Array[String] = JdbcBuilder.buildCTQueryParams(
       jdbcContext.ctChangesQueryParams,
-      jdbcContext.schema,
-      jdbcContext.table,
-      jdbcContext.ctLastVersion.toString,
-      jdbcContext.ctCurrentVersion.toString
+      jdbcContext
     )
     try {
       val jdbcDF: DataFrame = JdbcBuilder
@@ -67,10 +64,14 @@ class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) w
   ): BigInt = {
     val connection = DriverManager.getConnection(url)
     try {
+      val params: Array[String] = JdbcBuilder.buildCTQueryParams(
+        parameters,
+        jdbcContext
+      )
       val rs = JdbcBuilder.buildJDBCResultSet(
         connection,
         query,
-        parameters
+        params
       )
       rs.next()
       rs.getLong(1)

--- a/src/test/scala/mirroring/ChangeTrackingBuilderSuite.scala
+++ b/src/test/scala/mirroring/ChangeTrackingBuilderSuite.scala
@@ -15,7 +15,8 @@
  */
 package mirroring
 
-import mirroring.builders.ChangeTrackingBuilder
+import mirroring.builders.{ChangeTrackingBuilder, JdbcBuilder}
+import mirroring.services.databases.JdbcContext
 import org.scalatest.funsuite.AnyFunSuite
 
 class ChangeTrackingBuilderSuite extends AnyFunSuite {
@@ -81,5 +82,25 @@ class ChangeTrackingBuilderSuite extends AnyFunSuite {
         "CT.id as [SYS_CHANGE_PK_id], CT.FilId as [SYS_CHANGE_PK_FilId], CT.id2 as [SYS_CHANGE_PK_id2]"
       )
     )
+  }
+
+  test(
+    "buildCTQueryParams with default values"
+  ) {
+    val CTChangesQueryParams: Array[String] =
+      Array("defaultSQLTable", "X", "queryCTCurrentVersion", "queryCTLastVersion")
+    val jdbcContext: JdbcContext = JdbcContext(
+      jdbcUrl = "_jdbcUrl",
+      inTable = "tab",
+      inSchema = "schema",
+      numPart = "numPart",
+      splitby = "splitBy",
+      _CTChangesQuery = "CTChangesQuery",
+      _ctCurrentVersion = Some(BigInt(1)),
+      _CTChangesQueryParams = CTChangesQueryParams,
+      _changeTrackingLastVersion = () => Some(BigInt(2))
+    )
+    val result = JdbcBuilder.buildCTQueryParams(CTChangesQueryParams, jdbcContext)
+    assert(result sameElements Array("[schema].[tab]", "X", "1", "2"))
   }
 }


### PR DESCRIPTION
resolves #40 

### Description

Resolves bug that table is not created if not exists when using custom CT. 
Changes `buildCTChangesQueryParams` (is responsible for using default values). Instead of being used only for CTChangesQuery, alter name to `buildCTQueryParams` and make it applicable for parameters for all queries.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
