### PR TITLE
Custom ct large datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Library compares source and destination schemes. If column names don't match str
   e.g. `exec dbo.getCTMinValidVersionQuery ?`.
 * **ct_min_valid_version_params** `optional` Parameters for `ct_min_valid_version_query`.
 * **ct_current_version_query**      `optional` custom query to get Change Tracking changes,
-  e.g. `exec dbo.getCTChanges ?, ?, ?`.
+  e.g. `exec dbo.getCTChanges ?, ?`. Requires exactly two bigint params in order to get metadata.
 * **ct_current_version_params**      `optional` Parameters for `ct_current_version_query`.
 * **disable_platform_ingested_at**`optional` Set `true` if you want to disable autocreation
   column `_platform_ingested_at` on target.

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.12.10"
 val sparkVersion = "3.3.2"
-version := s"1.0.8-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.1.0-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",

--- a/src/main/scala/mirroring/Runner.scala
+++ b/src/main/scala/mirroring/Runner.scala
@@ -20,9 +20,16 @@ import io.delta.tables.DeltaTable
 import org.apache.spark.sql.DataFrame
 import mirroring.builders.{ConfigBuilder, DataframeBuilder, FilterBuilder}
 import mirroring.handlers.ChangeTrackingHandler
-import mirroring.services.databases.{JdbcCTService, JdbcPartitionedService, JdbcService}
+import mirroring.services.databases.{
+  JdbcCTService,
+  JdbcContext,
+  JdbcPartitionedService,
+  JdbcService
+}
 import mirroring.services.writer.{ChangeTrackingService, DeltaService, MergeService, WriterContext}
 import mirroring.services.{DeltaTableService, SparkService, SqlService}
+
+import scala.collection.mutable
 import wvlet.log.LogSupport
 
 object Runner extends LogSupport {
@@ -62,8 +69,8 @@ object Runner extends LogSupport {
       if (config.isChangeTrackingEnabled && isDeltaTableExists && config.CTChangesQuery.nonEmpty) {
         changeTrackingHandler.changeTrackingFlow(isDeltaTableExists, writerContext, jdbcContext)
         logger.info("Change Tracking: use custom ctChangesQuery")
-        val jdbcCTService: JdbcCTService = new JdbcCTService(jdbcContext)
-        jdbcCTService.loadData()
+        val url: String = getUrl(jdbcContext)
+        JdbcCTService.loadData(jdbcContext, url)
       } else {
         if (config.isChangeTrackingEnabled) {
           changeTrackingHandler.changeTrackingFlow(isDeltaTableExists, writerContext, jdbcContext)
@@ -105,5 +112,31 @@ object Runner extends LogSupport {
     if (config.hiveDb.nonEmpty) {
       SqlService.run(config)
     }
+  }
+
+  def getUrl(jdbcContext: JdbcContext): String = {
+    val MssqlUser: String     = sys.env.getOrElse("MSSQL_USER", "")
+    val MssqlPassword: String = sys.env.getOrElse("MSSQL_PASSWORD", "")
+
+    lazy val url: String = {
+      // If user/password are passed through environment variables, extract them and append to the url
+      val sb = new mutable.StringBuilder(jdbcContext.url)
+      if (
+        !jdbcContext.url.contains("user") && !jdbcContext.url.contains(
+          "password"
+        ) && MssqlUser.nonEmpty && MssqlPassword.nonEmpty
+      ) {
+        if (!jdbcContext.url.endsWith(";")) {
+          sb.append(";")
+        }
+        sb.append(s"user=$MssqlUser;password=$MssqlPassword")
+      }
+      require(
+        sb.toString.contains("password="),
+        "Parameters user and password are required for jdbc connection."
+      )
+      sb.toString
+    }
+    url
   }
 }

--- a/src/main/scala/mirroring/Runner.scala
+++ b/src/main/scala/mirroring/Runner.scala
@@ -83,6 +83,8 @@ object Runner extends LogSupport {
         jdbcService.loadData(query)
       }
 
+    logger.info(s"Number of incoming rows: ${jdbcDF.count}")
+
     val ds = DataframeBuilder.buildDataFrame(jdbcDF, config.getDataframeBuilderContext).cache()
     jdbcDF.unpersist()
 

--- a/src/main/scala/mirroring/builders/JdbcBuilder.scala
+++ b/src/main/scala/mirroring/builders/JdbcBuilder.scala
@@ -172,7 +172,7 @@ object JdbcBuilder extends LogSupport {
   }
 
   def resultSetToStringArray(rs: ResultSet): Array[Object] = {
-    Array.tabulate[Object](rs.getMetaData.getColumnCount)(i => rs.getObject(i + 1))
+    Array.tabulate[Object](rs.getMetaData.getColumnCount)(i => rs.getString(i + 1))
   }
 
   def buildDataFrameFromRS(rs: ResultSet): DataFrame = {

--- a/src/main/scala/mirroring/builders/JdbcBuilder.scala
+++ b/src/main/scala/mirroring/builders/JdbcBuilder.scala
@@ -47,10 +47,10 @@ object JdbcBuilder extends LogSupport {
     val md          = rs.getMetaData
     val columnCount = md.getColumnCount
     val structFieldsList: List[StructField] = (1 to columnCount).map { i =>
-      logger.info(i, md.getColumnName(i), md.getColumnType(i))
+      logger.info(i, md.getColumnName(i), md.getColumnType(i), md.getPrecision(i), md.getScale(i))
       StructField(
         md.getColumnName(i),
-        fromJavaSQLType(md.getColumnType(i)),
+        fromJavaSQLType(md.getColumnType(i), md.getPrecision(i), md.getScale(i)),
         md.isNullable(i) == 1
       )
     }.toList
@@ -84,11 +84,11 @@ object JdbcBuilder extends LogSupport {
     spark.createDataFrame(rs.map(Row.fromSeq(_)), schema)
   }
 
-  private def fromJavaSQLType(colType: Int): DataType = colType match {
+  private def fromJavaSQLType(colType: Int, precision: Int, scale: Int): DataType = colType match {
     case java.sql.Types.BOOLEAN | java.sql.Types.BIT                               => BooleanType
     case java.sql.Types.TINYINT | java.sql.Types.SMALLINT | java.sql.Types.INTEGER => IntegerType
     case java.sql.Types.BIGINT                                                     => LongType
-    case java.sql.Types.NUMERIC | java.sql.Types.DECIMAL                           => DecimalType(38, 10)
+    case java.sql.Types.NUMERIC | java.sql.Types.DECIMAL                           => DecimalType(precision, scale)
     case java.sql.Types.FLOAT                                                      => FloatType
     case java.sql.Types.DOUBLE                                                     => DoubleType
     case java.sql.Types.BINARY | java.sql.Types.VARBINARY | java.sql.Types.LONGVARBINARY =>

--- a/src/main/scala/mirroring/builders/JdbcBuilder.scala
+++ b/src/main/scala/mirroring/builders/JdbcBuilder.scala
@@ -47,7 +47,6 @@ object JdbcBuilder extends LogSupport {
     val md          = rs.getMetaData
     val columnCount = md.getColumnCount
     val structFieldsList: List[StructField] = (1 to columnCount).map { i =>
-      logger.info(i, md.getColumnName(i), md.getColumnType(i), md.getPrecision(i), md.getScale(i))
       StructField(
         md.getColumnName(i),
         fromJavaSQLType(md.getColumnType(i), md.getPrecision(i), md.getScale(i)),

--- a/src/main/scala/mirroring/builders/JdbcBuilder.scala
+++ b/src/main/scala/mirroring/builders/JdbcBuilder.scala
@@ -16,25 +16,15 @@
 
 package mirroring.builders
 
-import java.sql.{CallableStatement, Connection, ResultSet}
-import org.apache.spark.sql.types.{
-  BooleanType,
-  DateType,
-  DoubleType,
-  IntegerType,
-  FloatType,
-  LongType,
-  StringType,
-  StructField,
-  StructType,
-  TimestampType
-}
-import org.apache.spark.rdd.JdbcRDD
-import org.apache.spark.sql.{DataFrame, Row}
 import mirroring.builders.SqlBuilder.buildSQLObjectName
 import mirroring.services.SparkService.spark
 import mirroring.services.databases.JdbcContext
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row}
 import wvlet.log.LogSupport
+
+import java.sql.{CallableStatement, Connection, ResultSet}
 
 object JdbcBuilder extends LogSupport {
 
@@ -98,7 +88,7 @@ object JdbcBuilder extends LogSupport {
     params
   }
 
-  def buildDataFrameFromRDD(rs: JdbcRDD[Array[Object]], schema: StructType): DataFrame = {
+  def buildDataFrameFromRDD(rs: JavaRDD[Array[Object]], schema: StructType): DataFrame = {
     spark.createDataFrame(rs.map(Row.fromSeq(_)), schema)
   }
 

--- a/src/main/scala/mirroring/builders/JdbcBuilder.scala
+++ b/src/main/scala/mirroring/builders/JdbcBuilder.scala
@@ -89,7 +89,7 @@ object JdbcBuilder extends LogSupport {
     case java.sql.Types.TINYINT | java.sql.Types.SMALLINT | java.sql.Types.INTEGER => IntegerType
     case java.sql.Types.BIGINT                                                     => LongType
     case java.sql.Types.NUMERIC | java.sql.Types.DECIMAL                           => DecimalType(precision, scale)
-    case java.sql.Types.FLOAT                                                      => FloatType
+    case java.sql.Types.FLOAT | java.sql.Types.REAL                                => FloatType
     case java.sql.Types.DOUBLE                                                     => DoubleType
     case java.sql.Types.BINARY | java.sql.Types.VARBINARY | java.sql.Types.LONGVARBINARY =>
       BinaryType

--- a/src/main/scala/mirroring/handlers/ChangeTrackingHandler.scala
+++ b/src/main/scala/mirroring/handlers/ChangeTrackingHandler.scala
@@ -26,19 +26,22 @@ import wvlet.log.LogSupport
 
 class ChangeTrackingHandler(config: Config) extends LogSupport {
 
-  private lazy val jdbcContext                  = config.getJdbcContext
-  private lazy val jdbcCTService: JdbcCTService = new JdbcCTService(jdbcContext)
+  private lazy val jdbcContext = config.getJdbcContext
 
   lazy val ctCurrentVersion: BigInt = {
     logger.info(s"Querying current change tracking version from the source...")
     val version: BigInt = if (config.CTCurrentVersionQuery.isEmpty) {
       logger.info("Change Tracking: use default query to get CTCurrentVersion")
-      jdbcCTService.getChangeTrackingVersion(ChangeTrackingBuilder.currentVersionQuery)
+      JdbcCTService.getChangeTrackingVersion(
+        query = ChangeTrackingBuilder.currentVersionQuery,
+        jdbcContext = jdbcContext
+      )
     } else {
       logger.info("Change Tracking: use custom CTCurrentVersionQuery")
-      jdbcCTService.getChangeTrackingVersion(
-        config.CTCurrentVersionQuery,
-        config.CTCurrentVersionParams
+      JdbcCTService.getChangeTrackingVersion(
+        query = config.CTCurrentVersionQuery,
+        parameters = config.CTCurrentVersionParams,
+        jdbcContext = jdbcContext
       )
     }
     logger.info(s"Current CT version for the MSSQL table: $version")
@@ -51,14 +54,16 @@ class ChangeTrackingHandler(config: Config) extends LogSupport {
     )
     val version: BigInt = if (config.CTMinValidVersionQuery.isEmpty) {
       logger.info("Change Tracking: use default query to get ChangeTrackingMinValidVersion")
-      jdbcCTService.getChangeTrackingVersion(
-        ChangeTrackingBuilder.buildMinValidVersionQuery(config.schema, config.tab)
+      JdbcCTService.getChangeTrackingVersion(
+        query = ChangeTrackingBuilder.buildMinValidVersionQuery(config.schema, config.tab),
+        jdbcContext = jdbcContext
       )
     } else {
       logger.info("Change Tracking: use custom CTMinValidVersionQuery")
-      jdbcCTService.getChangeTrackingVersion(
-        config.CTMinValidVersionQuery,
-        config.CTMinValidVersionParams
+      JdbcCTService.getChangeTrackingVersion(
+        query = config.CTMinValidVersionQuery,
+        parameters = config.CTMinValidVersionParams,
+        jdbcContext = jdbcContext
       )
     }
     logger.info(s"Min valid version for the MSSQL table: $version")

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -38,7 +38,7 @@ class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) w
         params
       )
       logger.info("Building DataFrame from result set...")
-      val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromResultSet(resultSet).cache()
+      val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromResultSetTest(resultSet).cache()
       // spark.createDataFrame is lazy so action on jdbcDF is needed while ResultSet is open
       logger.info(s"Number of incoming rows: ${jdbcDF.count}")
       jdbcDF

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -20,11 +20,9 @@ import mirroring.services.SparkService.spark
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.rdd.JdbcRDD
 import mirroring.builders._
-import mirroring.services.SparkService.spark
 import wvlet.log.LogSupport
 
 import java.sql.{DriverManager, ResultSet}
-import scala.collection.mutable
 
 object JdbcCTService extends LogSupport {
 
@@ -36,7 +34,6 @@ object JdbcCTService extends LogSupport {
       jdbcContext
     )
     try {
-      logger.info(JdbcBuilder.getSchema())
       logger.info("Extracting result set...")
       val resultSet: ResultSet = JdbcBuilder.buildJDBCResultSet(
         connection1,
@@ -51,7 +48,7 @@ object JdbcCTService extends LogSupport {
         params(0).toInt,
         params(1).toInt,
         1,
-        r => JdbcBuilder.resultSetToStringArray(r)
+        r => JdbcRDD.resultSetToObjectArray(r)
       )
       logger.info("Building DataFrame from result set...")
       val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromRDD(myRDD, schema)

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -51,8 +51,8 @@ object JdbcCTService extends LogSupport {
         spark.sparkContext,
         cm,
         jdbcContext.ctChangesQuery,
-        params(0).toInt,
-        params(1).toInt,
+        params(0).toLong,
+        params(1).toLong,
         1,
         r => JdbcRDD.resultSetToObjectArray(r)
       )

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -15,7 +15,6 @@
  */
 
 package mirroring.services.databases
-import mirroring.Runner.getUrl
 import mirroring.builders._
 import mirroring.services.SparkService.spark
 import org.apache.spark.api.java.JavaRDD
@@ -28,10 +27,10 @@ import java.sql.{Connection, DriverManager, ResultSet}
 
 object JdbcCTService extends LogSupport {
 
-  def loadData(jdbcContext: JdbcContext, url: String): DataFrame = {
+  def loadData(jdbcContext: JdbcContext): DataFrame = {
     class ConnectionManager extends JdbcRDD.ConnectionFactory {
       override def getConnection: Connection = {
-        DriverManager.getConnection(url)
+        DriverManager.getConnection(jdbcContext.url)
       }
     }
     val cm: ConnectionManager = new ConnectionManager
@@ -78,8 +77,7 @@ object JdbcCTService extends LogSupport {
       parameters: Array[String],
       jdbcContext: JdbcContext
   ): BigInt = {
-    val url: String = getUrl(jdbcContext)
-    val connection  = DriverManager.getConnection(url)
+    val connection = DriverManager.getConnection(jdbcContext.url)
     try {
       val params: Array[String] = JdbcBuilder.buildCTQueryParams(
         parameters,

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.DataFrame
 import mirroring.builders._
 import wvlet.log.LogSupport
 
-import java.sql.DriverManager
+import java.sql.{DriverManager, ResultSet}
 
 class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) with LogSupport {
 
@@ -31,15 +31,14 @@ class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) w
       jdbcContext
     )
     try {
-      val jdbcDF: DataFrame = JdbcBuilder
-        .buildDataFrameFromResultSet(
-          JdbcBuilder.buildJDBCResultSet(
-            connection,
-            jdbcContext.ctChangesQuery,
-            params
-          )
-        )
-        .cache()
+      logger.info("Extracting result set...")
+      val resultSet: ResultSet = JdbcBuilder.buildJDBCResultSet(
+        connection,
+        jdbcContext.ctChangesQuery,
+        params
+      )
+      logger.info("Building DataFrame from result set...")
+      val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromResultSet(resultSet).cache()
       // spark.createDataFrame is lazy so action on jdbcDF is needed while ResultSet is open
       logger.info(s"Number of incoming rows: ${jdbcDF.count}")
       jdbcDF

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -16,6 +16,7 @@
 
 package mirroring.services.databases
 
+import org.apache.spark.rdd.JdbcRDD
 import org.apache.spark.sql.DataFrame
 import mirroring.builders._
 import wvlet.log.LogSupport
@@ -25,7 +26,7 @@ import java.sql.{DriverManager, ResultSet}
 class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) with LogSupport {
 
   override def loadData(@annotation.unused _query: String = ""): DataFrame = {
-    val connection = DriverManager.getConnection(url)
+    @transient lazy val connection = DriverManager.getConnection(url)
     val params: Array[String] = JdbcBuilder.buildCTQueryParams(
       jdbcContext.ctChangesQueryParams,
       jdbcContext
@@ -38,7 +39,7 @@ class JdbcCTService(jdbcContext: JdbcContext) extends JdbcService(jdbcContext) w
         params
       )
       logger.info("Building DataFrame from result set...")
-      val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromResultSetTest(resultSet).cache()
+      val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromResultSet(resultSet).cache()
       // spark.createDataFrame is lazy so action on jdbcDF is needed while ResultSet is open
       logger.info(s"Number of incoming rows: ${jdbcDF.count}")
       jdbcDF

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -59,10 +59,7 @@ object JdbcCTService extends LogSupport {
         r => JdbcRDD.resultSetToObjectArray(r)
       )
       logger.info("Building DataFrame from result set...")
-      val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromRDD(myRDD, schema)
-      // spark.createDataFrame is lazy so action on jdbcDF is needed while ResultSet is open
-      logger.info(s"Number of incoming rows: ${jdbcDF.count}")
-      jdbcDF
+      JdbcBuilder.buildDataFrameFromRDD(myRDD, schema).cache()
     } catch {
       case e: Exception =>
         logger.error(

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -40,15 +40,15 @@ object JdbcCTService extends LogSupport {
       jdbcContext
     )
     try {
-      logger.debug("Executing procedure with Long.MaxValue to get schema...")
+      logger.info("Executing procedure with Long.MaxValue to get schema...")
       val resultSet: ResultSet = JdbcBuilder.buildJDBCResultSet(
         cm.getConnection,
         jdbcContext.ctChangesQuery,
         Array(Long.MaxValue.toString, Long.MaxValue.toString)
       )
       val schema: StructType = JdbcBuilder.buildStructFromResultSet(resultSet)
-      logger.debug(schema)
-      logger.debug("Executing procedure to create rdd...")
+      logger.info(schema)
+      logger.info("Executing procedure to create rdd...")
       val myRDD: JavaRDD[Array[Object]] = JdbcRDD.create(
         spark.sparkContext,
         cm,
@@ -58,7 +58,7 @@ object JdbcCTService extends LogSupport {
         1,
         r => JdbcRDD.resultSetToObjectArray(r)
       )
-      logger.debug("Building DataFrame from result set...")
+      logger.info("Building DataFrame from result set...")
       val jdbcDF: DataFrame = JdbcBuilder.buildDataFrameFromRDD(myRDD, schema)
       // spark.createDataFrame is lazy so action on jdbcDF is needed while ResultSet is open
       logger.info(s"Number of incoming rows: ${jdbcDF.count}")

--- a/src/main/scala/mirroring/services/databases/JdbcPartitionedService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcPartitionedService.scala
@@ -105,6 +105,6 @@ class JdbcPartitionedService(
     logger.info(s"Reading data with query: ${_query}")
     // setting query to use it in the lower/upper bounds calculations
     query = _query
-    super[JdbcService].dfReader.options(options).option("dbtable", _query).load().cache()
+    dfReader.options(options).option("dbtable", _query).load().cache()
   }
 }

--- a/src/main/scala/mirroring/services/databases/JdbcPartitionedService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcPartitionedService.scala
@@ -105,9 +105,6 @@ class JdbcPartitionedService(
     logger.info(s"Reading data with query: ${_query}")
     // setting query to use it in the lower/upper bounds calculations
     query = _query
-    val jdbcDF =
-      super[JdbcService].dfReader.options(options).option("dbtable", _query).load().cache()
-    logger.info(s"Number of incoming rows: ${jdbcDF.count}")
-    jdbcDF
+    super[JdbcService].dfReader.options(options).option("dbtable", _query).load().cache()
   }
 }

--- a/src/main/scala/mirroring/services/databases/JdbcService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcService.scala
@@ -21,34 +21,7 @@ import mirroring.DatatypeMapping
 import mirroring.services.SparkService.spark
 import wvlet.log.LogSupport
 
-import scala.collection.mutable
-
 class JdbcService(jdbcContext: JdbcContext) extends LogSupport {
-
-  val MssqlUser: String     = sys.env.getOrElse("MSSQL_USER", "")
-  val MssqlPassword: String = sys.env.getOrElse("MSSQL_PASSWORD", "")
-
-  lazy val url: String = {
-    // If user/password are passed through environment variables, extract them and append to the url
-    val sb = new mutable.StringBuilder(jdbcContext.url)
-    if (
-      !jdbcContext.url.contains("user") && !jdbcContext.url.contains(
-        "password"
-      ) && MssqlUser.nonEmpty && MssqlPassword.nonEmpty
-    ) {
-      if (!jdbcContext.url.endsWith(";")) {
-        sb.append(";")
-      }
-      sb.append(s"user=$MssqlUser;password=$MssqlPassword")
-    }
-
-    require(
-      sb.toString.contains("password="),
-      "Parameters user and password are required for jdbc connection."
-    )
-
-    sb.toString
-  }
 
   protected lazy val customSchema: String = {
     val sql =
@@ -56,7 +29,7 @@ class JdbcService(jdbcContext: JdbcContext) extends LogSupport {
         s"TABLE_NAME = '${jdbcContext.table}' and TABLE_SCHEMA = '${jdbcContext.schema}') as subq"
 
     val sourceSchema =
-      spark.read.format("jdbc").option("url", url).option("dbtable", sql).load()
+      spark.read.format("jdbc").option("url", jdbcContext.url).option("dbtable", sql).load()
 
     // create custom schema to avoid transferring DATE as STRING
     // viz https://jtds.sourceforge.net/typemap.html
@@ -89,7 +62,7 @@ class JdbcService(jdbcContext: JdbcContext) extends LogSupport {
   def dfReader: DataFrameReader = {
     spark.read
       .format("jdbc")
-      .option("url", url)
+      .option("url", jdbcContext.url)
       .option("customSchema", customSchema)
   }
 }

--- a/src/main/scala/mirroring/services/databases/JdbcService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcService.scala
@@ -83,9 +83,7 @@ class JdbcService(jdbcContext: JdbcContext) extends LogSupport {
   }
   def loadData(_query: String): DataFrame = {
     logger.info(s"Reading data with query: ${_query}")
-    val jdbcDF = dfReader.option("dbtable", _query).load().cache()
-    logger.info(s"Number of incoming rows: ${jdbcDF.count}")
-    jdbcDF
+    dfReader.option("dbtable", _query).load().cache()
   }
 
   def dfReader: DataFrameReader = {


### PR DESCRIPTION
Resolves problem of hanging jobs when multiple millions of rows are transferred using custom change tracking.

### Description

Fixes issues:
- job is hanging when multiple millions of rows are transferred using custom change tracking
- timezone is ignored when using `generate_column` with `generated_column_exp` on timestamp column when custom change tracking is used (caused by columns got with custom change tracking are parsed as StringType leading to ignoring timezones)

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md file
