### PR TITLE
Bump to 1.0.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.12.10"
 val sparkVersion = "3.3.2"
-version := s"1.0.9-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.0.8-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.12.10"
 val sparkVersion = "3.3.2"
-version := s"1.0.8a3-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.0.9-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",


### PR DESCRIPTION
## 1.0.8 (2023-04-24)

#### Improvements
  - Move _platform_ingested_at to the first place in dataset(#45 )
  - Make CTChangesQuery applicable for parameters for all queries instead of only for CTChangesQuery (#41 )
#### Bugfixes
  - Fix partition bug for CT when partition_col is included in PK, merge condition is formed using original partition_col even though for CT SYS_CHANGE_PK_<column_name> should be used (#39 )
  - Fix bug table is not created if not exists when using custom CT (#41 )