### PR TITLE
Enable repartitionBeforeWrite for merge operations

### DIFF
--- a/src/main/scala/mirroring/services/writer/ChangeTrackingService.scala
+++ b/src/main/scala/mirroring/services/writer/ChangeTrackingService.scala
@@ -17,13 +17,12 @@
 package mirroring.services.writer
 
 import io.delta.tables.DeltaTable
-import mirroring.UserMetadata
 import mirroring.builders.FilterBuilder
-import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row}
 import mirroring.services.SparkService.spark
+import mirroring.{Config, UserMetadata}
+import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row}
 import wvlet.airframe.codec.MessageCodec
 import wvlet.log.LogSupport
-import mirroring.Config
 
 class ChangeTrackingService(
     context: WriterContext
@@ -49,6 +48,12 @@ class ChangeTrackingService(
         "spark.databricks.delta.commitInfo.userMetadata",
         userMetadataJSON
       )
+      if (context.lastPartitionCol.nonEmpty) {
+        spark.conf.set(
+          "spark.databricks.delta.merge.repartitionBeforeWrite.enabled",
+          "true"
+        )
+      }
 
       val condition = FilterBuilder.buildMergeCondition(
         context.primaryKey,

--- a/src/main/scala/mirroring/services/writer/MergeService.scala
+++ b/src/main/scala/mirroring/services/writer/MergeService.scala
@@ -17,11 +17,11 @@
 package mirroring.services.writer
 
 import io.delta.tables.DeltaTable
-import mirroring.builders.FilterBuilder
-import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row}
-import mirroring.services.SparkService.spark
-import wvlet.log.LogSupport
 import mirroring.Config
+import mirroring.builders.FilterBuilder
+import mirroring.services.SparkService.spark
+import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row}
+import wvlet.log.LogSupport
 
 class MergeService(context: WriterContext) extends DeltaService(context) with LogSupport {
 
@@ -31,6 +31,12 @@ class MergeService(context: WriterContext) extends DeltaService(context) with Lo
 
       verifySchemaMatch(data)
 
+      if (context.lastPartitionCol.nonEmpty) {
+        spark.conf.set(
+          "spark.databricks.delta.merge.repartitionBeforeWrite.enabled",
+          "true"
+        )
+      }
       DeltaTable
         .forPath(spark, context.path)
         .as(Config.TargetAlias)


### PR DESCRIPTION
### Description
From documentation: 

> For partitioned tables, merge can produce a much larger number of small files than the number of shuffle partitions. This is because every shuffle task can write multiple files in multiple partitions, and can become a performance bottleneck. In many cases, it helps to repartition the output data by the table’s partition columns before writing it. You enable this by setting the Spark session configuration spark.databricks.delta.merge.repartitionBeforeWrite.enabled to true.



### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
