### PR TITLE
Added repartition after jdbc load

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ headerLicense := Some(
 name := "DeltaFlow"
 scalaVersion := "2.12.10"
 val sparkVersion = "3.3.2"
-version := s"1.1.2-spark${sparkVersion}-scala${scalaVersion.value}"
+version := s"1.1.3-spark${sparkVersion}-scala${scalaVersion.value}"
 libraryDependencies ++= Seq(
   "org.apache.spark"   %% "spark-core"         % sparkVersion % "provided",
   "org.apache.spark"   %% "spark-sql"          % sparkVersion % "provided",

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -38,6 +38,35 @@ object JdbcCTService extends LogSupport {
       jdbcContext.ctChangesQueryParams,
       jdbcContext
     )
+    val resultSet: ResultSet = getSchema(jdbcContext, cm)
+    try {
+      val schema: StructType = JdbcBuilder.buildStructFromResultSet(resultSet)
+      logger.debug(schema)
+      logger.info("Executing procedure to create rdd...")
+      val myRDD: JavaRDD[Array[Object]] = JdbcRDD.create(
+        spark.sparkContext,
+        cm,
+        jdbcContext.ctChangesQuery,
+        params(0).toLong,
+        params(1).toLong,
+        1,
+        r => JdbcRDD.resultSetToObjectArray(r)
+      )
+      logger.info("Building DataFrame from result set...")
+      JdbcBuilder.buildDataFrameFromRDD(
+        myRDD.repartition(spark.conf.get("spark.sql.shuffle.partitions").toInt),
+        schema
+      )
+    } catch {
+      case e: Exception =>
+        logger.error(
+          s"Error executing ${jdbcContext.ctChangesQuery} with params: ${params.mkString(", ")}"
+        )
+        throw e
+    }
+  }
+
+  private def getSchema(jdbcContext: JdbcContext, cm: JdbcRDD.ConnectionFactory): ResultSet = {
     val maxValueParams: Array[String] = Array(Long.MaxValue.toString, Long.MaxValue.toString)
     val resultSet: ResultSet =
       try {
@@ -54,28 +83,7 @@ object JdbcCTService extends LogSupport {
           )
           throw e
       }
-    try {
-      val schema: StructType = JdbcBuilder.buildStructFromResultSet(resultSet)
-      logger.info(schema)
-      logger.info("Executing procedure to create rdd...")
-      val myRDD: JavaRDD[Array[Object]] = JdbcRDD.create(
-        spark.sparkContext,
-        cm,
-        jdbcContext.ctChangesQuery,
-        params(0).toLong,
-        params(1).toLong,
-        1,
-        r => JdbcRDD.resultSetToObjectArray(r)
-      )
-      logger.info("Building DataFrame from result set...")
-      JdbcBuilder.buildDataFrameFromRDD(myRDD, schema)
-    } catch {
-      case e: Exception =>
-        logger.error(
-          s"Error executing ${jdbcContext.ctChangesQuery} with params: ${params.mkString(", ")}"
-        )
-        throw e
-    }
+    resultSet
   }
 
   /** Returns value from the first row, first column of the result set as BigInt.

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -33,19 +33,19 @@ object JdbcCTService extends LogSupport {
         DriverManager.getConnection(jdbcContext.url)
       }
     }
-    val cm: ConnectionManager = new ConnectionManager
+    val connectionManager: ConnectionManager = new ConnectionManager
     val params: Array[String] = JdbcBuilder.buildCTQueryParams(
       jdbcContext.ctChangesQueryParams,
       jdbcContext
     )
-    val resultSet: ResultSet = getSchema(jdbcContext, cm)
+    val resultSet: ResultSet = getSchema(jdbcContext, connectionManager)
     try {
       val schema: StructType = JdbcBuilder.buildStructFromResultSet(resultSet)
       logger.debug(schema)
       logger.info("Executing procedure to create rdd...")
       val myRDD: JavaRDD[Array[Object]] = JdbcRDD.create(
         spark.sparkContext,
-        cm,
+        connectionManager,
         jdbcContext.ctChangesQuery,
         params(0).toLong,
         params(1).toLong,

--- a/src/main/scala/mirroring/services/databases/JdbcPartitionedService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcPartitionedService.scala
@@ -16,6 +16,7 @@
 
 package mirroring.services.databases
 
+import mirroring.services.SparkService.spark
 import org.apache.spark.sql.functions.{col, date_format, date_trunc}
 import org.apache.spark.sql.{DataFrame, Encoders}
 import wvlet.log.LogSupport
@@ -104,6 +105,10 @@ class JdbcPartitionedService(
     logger.info(s"Reading data with query: ${_query}")
     // setting query to use it in the lower/upper bounds calculations
     query = _query
-    dfReader.options(options).option("dbtable", _query).load()
+    dfReader
+      .options(options)
+      .option("dbtable", _query)
+      .load()
+      .repartition(spark.conf.get("spark.sql.shuffle.partitions").toInt)
   }
 }

--- a/src/main/scala/mirroring/services/databases/JdbcService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcService.scala
@@ -56,7 +56,10 @@ class JdbcService(jdbcContext: JdbcContext) extends LogSupport {
   }
   def loadData(_query: String): DataFrame = {
     logger.info(s"Reading data with query: ${_query.linesIterator.mkString(" ").trim}")
-    dfReader.option("dbtable", _query).load()
+    dfReader
+      .option("dbtable", _query)
+      .load()
+      .repartition(spark.conf.get("spark.sql.shuffle.partitions").toInt)
   }
 
   def dfReader: DataFrameReader = {


### PR DESCRIPTION
resolves #53 

### Description
Repartition is added after the data is loaded from jdbs source. In this case dataset will be partitioned by default number of partitions instead of "splitby" used by jdbc connection. 

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
