### PR TITLE
Refactored getChangeTrackingVersion method

### DIFF
--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -129,8 +129,9 @@ object JdbcCTService extends LogSupport {
         .as[Long]
         .first()
     } catch {
-      case e: java.util.NoSuchElementException =>
-        logger.info(s"Cannot retrieve change tracking version using: ${query}, using 0")
+      case e: java.lang.NullPointerException =>
+        logger.error(s"Change tracking is not enabled on queried table: ${query}")
+        throw e
     }
     version
   }

--- a/src/main/scala/mirroring/services/databases/JdbcCTService.scala
+++ b/src/main/scala/mirroring/services/databases/JdbcCTService.scala
@@ -20,6 +20,7 @@ import mirroring.services.SparkService.spark
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.JdbcRDD
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.delta.implicits.longEncoder
 import org.apache.spark.sql.types.StructType
 import wvlet.log.LogSupport
 
@@ -118,17 +119,18 @@ object JdbcCTService extends LogSupport {
   }
 
   def getChangeTrackingVersion(query: String, jdbcContext: JdbcContext): BigInt = {
-    val jdbcService: JdbcService = new JdbcService(jdbcContext)
-    val jdbcDF: DataFrame        = jdbcService.loadData(query)
-
     var version: BigInt = BigInt(0)
-
-    if (!jdbcDF.isEmpty) {
-      version = BigInt(
-        jdbcDF
-          .collect()(0)
-          .getLong(0)
-      )
+    try {
+      version = spark.read
+        .format("jdbc")
+        .option("url", jdbcContext.url)
+        .option("dbtable", query)
+        .load()
+        .as[Long]
+        .first()
+    } catch {
+      case e: java.util.NoSuchElementException =>
+        logger.info(s"Cannot retrieve change tracking version using: ${query}, using 0")
     }
     version
   }


### PR DESCRIPTION
### Description
Refactored getChangeTrackingVersion method not to use JdbcService.loadData since it's querying MSSQL server for custom schema and this is not necessary here. 

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
