### PR TITLE
Removed spark application name

### DIFF
--- a/src/main/scala/mirroring/services/SparkService.scala
+++ b/src/main/scala/mirroring/services/SparkService.scala
@@ -22,7 +22,6 @@ object SparkService {
 
   val spark: SparkSession = SparkSession
     .builder()
-    .appName("DataMirroring")
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
     .config(
       "spark.sql.catalog.spark_catalog",


### PR DESCRIPTION
### Description
Removed spark application name so user can set It dynamically via `spark.app.name` or the default will be used (which is, in case of k8s, a driver pod name)

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
