### PR TITLE
Exclude optimize operation from user metadata history

### DIFF
--- a/src/main/scala/mirroring/handlers/ChangeTrackingHandler.scala
+++ b/src/main/scala/mirroring/handlers/ChangeTrackingHandler.scala
@@ -74,7 +74,8 @@ class ChangeTrackingHandler(config: Config) extends LogSupport {
   private lazy val ctDeltaVersion: BigInt = {
     val userMetaJSON = DeltaTable
       .forPath(spark, config.pathToSave)
-      .history(1)
+      .history()
+      .where("operation <> 'OPTIMIZE'")
       .select("userMetadata")
       .collect()(0)
       .getString(0)


### PR DESCRIPTION
### Description
When there is a programmatically triggered operation between merges, there is a history record that doesn't have user metadata. Because of that, the min valid version of CT is used instead of the one from the table.
This PR removes OPTIMIZE command from the history dataset to avoid this situation. 

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md file
